### PR TITLE
chore: (front) eslint react 관련 오류 수정

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -10,6 +10,7 @@
 	},
 	"plugins": ["react"],
 	"rules": {
-		"react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+		"react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+		"react/react-in-jsx-scope": "off"
 	}
 }


### PR DESCRIPTION
## Summary
react & eslint 관련 오류 수정

## Related Issue
X

## Description(optional)
```
import React from 'react'
import ReactDOM from 'react-dom'
```
react 17v 이상부터 위와 같은 dependency가 불필요함
위 코드를 포함하거나 eslint에서 옵션을 추가하여 오류를 제거