### PR TITLE
로그인 유지 기능 구현

### DIFF
--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -1,9 +1,0 @@
-import axios from 'axios';
-
-const oauthLogin = async (oauthType) => {
-	const response = await axios.get(`/api/auth/login/oauth?type=${oauthType}`);
-	const { pageUrl } = response.data;
-	window.location.href = pageUrl;
-};
-
-export default oauthLogin;

--- a/client/src/components/LoginButton.jsx
+++ b/client/src/components/LoginButton.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import githubLogo from 'assets/images/logos/github-mark-white.png';
-import useOauthLogin from 'hooks/auth';
+import { useOauthLogin } from 'hooks/auth';
 
 const LOGIN_MSG = 'Log in with GitHub';
 

--- a/client/src/components/LoginButton.jsx
+++ b/client/src/components/LoginButton.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import githubLogo from 'assets/images/logos/github-mark-white.png';
-import oauthLogin from 'api/auth';
+import useOauthLogin from 'hooks/auth';
 
 const LOGIN_MSG = 'Log in with GitHub';
 
@@ -25,6 +25,8 @@ const GithubLogo = styled.img`
 `;
 
 function LoginButton() {
+	const oauthLogin = useOauthLogin();
+
 	return (
 		<ButtonWrapper onClick={() => oauthLogin('github')}>
 			<GithubLogo src={githubLogo} alt="github logo" />

--- a/client/src/hooks/auth.js
+++ b/client/src/hooks/auth.js
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+
+const useOauthLogin = () => {
+	const navigate = useNavigate();
+
+	const oauthLogin = async (oauthType) => {
+		try {
+			const response = await axios.get(`/api/auth/login/oauth?type=${oauthType}`);
+			const { pageUrl } = response.data;
+			window.location.href = pageUrl;
+		} catch (err) {
+			const { status } = err.response;
+			if (status === 401) {
+				navigate('/');
+			}
+		}
+	};
+
+	return oauthLogin;
+};
+
+export default useOauthLogin;

--- a/client/src/hooks/auth.js
+++ b/client/src/hooks/auth.js
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
-const useOauthLogin = () => {
+export const useOauthLogin = () => {
 	const navigate = useNavigate();
 
 	const oauthLogin = async (oauthType) => {
@@ -20,4 +20,20 @@ const useOauthLogin = () => {
 	return oauthLogin;
 };
 
-export default useOauthLogin;
+export const useAuthenticate = () => {
+	const navigate = useNavigate();
+
+	const authenticate = async () => {
+		try {
+			await axios.get('/api/auth/authentication');
+			navigate('/main');
+		} catch (err) {
+			const { status } = err.response;
+			if (status === 401) {
+				navigate('/');
+			}
+		}
+	};
+
+	return authenticate;
+};

--- a/client/src/pages/LandingPages/LandingPage.jsx
+++ b/client/src/pages/LandingPages/LandingPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import Header from 'components/layout/Header';
@@ -10,6 +10,7 @@ import IntroContainerFirst from 'components/Landing/IntroContainerFirst';
 import IntroContainerSecond from 'components/Landing/IntroContainerSecond';
 import LogosContainer from 'components/Landing/LogosContainer';
 import LoginContainer from 'components/Landing/LoginContainer';
+import { useAuthenticate } from 'hooks/auth';
 
 const Wrapper = styled.div`
 	width: 100%;
@@ -28,6 +29,12 @@ const Content = styled.main`
 `;
 
 function LandingPage() {
+	const authenticate = useAuthenticate();
+
+	useEffect(() => {
+		authenticate();
+	}, []);
+
 	return (
 		<Wrapper>
 			<Header />

--- a/server/src/user/auth/controller/auth.controller.ts
+++ b/server/src/user/auth/controller/auth.controller.ts
@@ -1,12 +1,13 @@
-import { Controller, Get, Query, Res } from '@nestjs/common';
+import { Controller, Get, Query, Req, Res, UseGuards } from '@nestjs/common';
 import { AuthService } from '../service/auth.service';
 import { OauthUrlDto } from 'src/user/dto/oauth-url.dto';
 import { OauthType, jwtCookieOptions } from 'src/constant/auth.constant';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { UserRepository } from '../repository/auth.repository';
 import { JwtPayload } from '@type';
 import { CLIENT_DOMAIN } from '@constant';
+import { JwtAuthGuard } from '../guard/jwt.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -40,5 +41,11 @@ export class AuthController {
 		const accessToken = this.authService.createAccessToken(user as JwtPayload);
 		res.cookie('accessToken', accessToken, jwtCookieOptions);
 		res.redirect(this.configService.get<string>(CLIENT_DOMAIN));
+	}
+
+	@UseGuards(JwtAuthGuard)
+	@Get('authentication')
+	async authentication(@Req() req: Request) {
+		return { user: req.user };
 	}
 }


### PR DESCRIPTION
## Summary
- backend authentication api  구현
- frontend landing page에 관련 api 로직 추가
- 인증이 되면 main으로 navigate

## Related Issue
- close #18 

## Description(optional)
내부적으로 navigate hook을 써야하기 때문에 기존의 단순 method에서 custom hook으로 분리했습니다.
