### PR TITLE
feat: (back) 코딩테스트 문제 api 구현

### DIFF
--- a/server/src/problem/dto/create-problem.dto.ts
+++ b/server/src/problem/dto/create-problem.dto.ts
@@ -4,4 +4,5 @@ export class CreateProblemDto {
 	tags: string[];
 	description: string;
 	constraint: string[];
+	testcases: object[];
 }

--- a/server/src/problem/entities/problem.entity.ts
+++ b/server/src/problem/entities/problem.entity.ts
@@ -19,6 +19,9 @@ export class ProblemEntity {
 
 	@Prop({ required: true })
 	constraint: string[];
+
+	@Prop({ required: true })
+	testcases: object[];
 }
 
 export const ProblemSchema = SchemaFactory.createForClass(ProblemEntity);

--- a/server/src/problem/problem.controller.ts
+++ b/server/src/problem/problem.controller.ts
@@ -1,10 +1,14 @@
 import { Controller, Get, Post, Body, Param, Query } from '@nestjs/common';
 import { CreateProblemDto } from './dto/create-problem.dto';
 import { ProblemRepository } from './repository/problem.repository';
+import { ProblemService } from './problem.service';
 
 @Controller('problem')
 export class ProblemController {
-	constructor(private readonly problemRepository: ProblemRepository) {}
+	constructor(
+		private readonly problemRepository: ProblemRepository,
+		private readonly problemService: ProblemService
+	) {}
 
 	@Post('')
 	create(@Body() createProblemDto: CreateProblemDto) {
@@ -16,13 +20,13 @@ export class ProblemController {
 		return this.problemRepository.getCodetestSet(+difficulty, +num);
 	}
 
+	@Get('codingtest')
+	getCodeSet(@Query('difficulty') difficulty: string, @Query('num') num: string) {
+		return this.problemService.getCodingtestSet(+difficulty, +num);
+	}
+
 	@Get(':id')
 	findOne(@Param('id') id: string) {
 		return this.problemRepository.findOne(id);
-	}
-
-	@Get('codingtest')
-	getCodeSet(@Query('difficulty') difficulty: string, @Query('num') num: string) {
-		return;
 	}
 }

--- a/server/src/problem/problem.controller.ts
+++ b/server/src/problem/problem.controller.ts
@@ -20,4 +20,9 @@ export class ProblemController {
 	findOne(@Param('id') id: string) {
 		return this.problemRepository.findOne(id);
 	}
+
+	@Get('codingtest')
+	getCodeSet(@Query('difficulty') difficulty: string, @Query('num') num: string) {
+		return;
+	}
 }

--- a/server/src/problem/problem.module.ts
+++ b/server/src/problem/problem.module.ts
@@ -3,10 +3,11 @@ import { ProblemController } from './problem.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ProblemSchema } from './entities/problem.entity';
 import { ProblemRepository } from './repository/problem.repository';
+import { ProblemService } from './problem.service';
 
 @Module({
 	imports: [MongooseModule.forFeature([{ name: 'Problem', schema: ProblemSchema }])],
 	controllers: [ProblemController],
-	providers: [ProblemRepository],
+	providers: [ProblemRepository, ProblemService],
 })
 export class ProblemModule {}

--- a/server/src/problem/problem.service.ts
+++ b/server/src/problem/problem.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ProblemRepository } from './repository/problem.repository';
+
+@Injectable()
+export class ProblemService {
+	constructor(private readonly problemRepository: ProblemRepository) {}
+
+	async getCodingtestSet(difficulty: number, num: number) {
+		const ids = await this.problemRepository.getCodetestSet(difficulty, num);
+
+		const res = { problemInfo: [] };
+		for (const id of ids) {
+			const problem = await this.problemRepository.findOne(id);
+			res.problemInfo.push({
+				_id: problem._id,
+				title: problem.title,
+				description: problem.description,
+				constraint: problem.constraint,
+				testcases: problem.testcases,
+			});
+		}
+
+		return res;
+	}
+}

--- a/server/src/problem/repository/problem.repository.ts
+++ b/server/src/problem/repository/problem.repository.ts
@@ -28,6 +28,7 @@ export class ProblemRepository {
 				tags: problem.tags,
 				description: problem.description,
 				constraint: problem.constraint,
+				testcases: problem.testcases,
 			};
 		} catch (error) {
 			throw new Error(error);

--- a/server/src/types/problem.type.ts
+++ b/server/src/types/problem.type.ts
@@ -7,6 +7,7 @@ export interface Problem {
 	tags: string[];
 	description: string;
 	constraint: string[];
+	testcases: object[];
 }
 
 export interface MetaProblem {
@@ -21,4 +22,5 @@ export interface ProblemDescription {
 	title: string;
 	description: string;
 	constraint: string[];
+	testcases: object[];
 }


### PR DESCRIPTION
## Summary
코딩 테스트 문제 세트를 요청할 수 있는 api를 구현하였습니다.

## Related Issue
PS page

## Description(optional)
사용법: GET [host]/api/problem/codingtest?difficulty=\<number\>&num=\<number\>
 -> difficulty 난이도에 맞는 문제를 num 개수 이내로 있는 만큼 반환합니다.